### PR TITLE
Run Juroku as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,10 @@ FROM alpine:3.12
 WORKDIR /usr/bin/
 
 COPY juroku-server /usr/bin
-RUN apk add libgomp ffmpeg youtube-dl
+RUN apk add libgomp ffmpeg youtube-dl \
+    && addgroup -g 1000 -S juroku \
+    && adduser -u 1000 -S juroku -G juroku
 
 EXPOSE 9999
-
-CMD ["/usr/bin/juroku-server"]
+USER juroku
+CMD ["juroku-server"]


### PR DESCRIPTION
This improves security for the container and host system.